### PR TITLE
Add SIGUSR1 and SIGUSR2

### DIFF
--- a/examples/test_many.rs
+++ b/examples/test_many.rs
@@ -10,7 +10,7 @@ fn main() {
     chan_signal::notify_on(&s1, Signal::HUP);
     chan_signal::notify_on(&s2, Signal::TERM);
     kill_this(Signal::HUP);
-    kill_this(Signal::TERM);
     assert_eq!(r1.recv(), Some(Signal::HUP));
+    kill_this(Signal::TERM);
     assert_eq!(r2.recv(), Some(Signal::TERM));
 }

--- a/examples/test_usr1.rs
+++ b/examples/test_usr1.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate chan;
+extern crate chan_signal;
+
+use chan_signal::{Signal, kill_this};
+
+fn main() {
+    let (s, r) = chan::sync(1);
+    chan_signal::notify_on(&s, Signal::USR1);
+    kill_this(Signal::USR1);
+    assert_eq!(r.recv(), Some(Signal::USR1));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ use bit_set::BitSet;
 use chan::Sender;
 use libc::{
     SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGABRT, SIGFPE, SIGKILL,
-    SIGSEGV, SIGPIPE, SIGALRM, SIGTERM,
+    SIGSEGV, SIGPIPE, SIGALRM, SIGTERM, SIGUSR1, SIGUSR2,
 };
 use libc::kill;
 use libc::getpid;
@@ -241,6 +241,8 @@ pub enum Signal {
     PIPE,
     ALRM,
     TERM,
+    USR1,
+    USR2,
     #[doc(hidden)]
     __NonExhaustiveMatch,
 }
@@ -259,6 +261,8 @@ impl Signal {
             SIGPIPE => Signal::PIPE,
             SIGALRM => Signal::ALRM,
             SIGTERM => Signal::TERM,
+            SIGUSR1 => Signal::USR1,
+            SIGUSR2 => Signal::USR2,
             sig => panic!("unsupported signal number: {}", sig),
         }
     }
@@ -276,6 +280,8 @@ impl Signal {
             Signal::PIPE => SIGPIPE,
             Signal::ALRM => SIGALRM,
             Signal::TERM => SIGTERM,
+            Signal::USR1 => SIGUSR1,
+            Signal::USR2 => SIGUSR2,
             Signal::__NonExhaustiveMatch => unreachable!(),
         }
     }
@@ -306,6 +312,8 @@ impl SigSet {
         set.add(SIGPIPE).unwrap();
         set.add(SIGALRM).unwrap();
         set.add(SIGTERM).unwrap();
+        set.add(SIGUSR1).unwrap();
+        set.add(SIGUSR2).unwrap();
         set
     }
 


### PR DESCRIPTION
It's often useful to be able to handle SIGUSR1 and SIGUSR2 in an application, and this wasn't yet possible with chan-signal.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/burntsushi/chan-signal/6)

<!-- Reviewable:end -->
