### PR TITLE
Allow unblocking of non-subscribed signals

### DIFF
--- a/examples/test_block_specific.rs
+++ b/examples/test_block_specific.rs
@@ -1,0 +1,22 @@
+#[macro_use]
+extern crate chan;
+extern crate chan_signal;
+
+use chan_signal::{Signal, kill_this};
+
+fn main() {
+    chan_signal::unblock_signals_by_default();
+    let r_usr1 = chan_signal::notify(&[Signal::USR1]);
+    kill_this(Signal::USR1);
+    assert_eq!(r_usr1.recv(), Some(Signal::USR1));
+
+    let (s, r_usr2) = chan::sync(1);
+    chan_signal::notify_on(&s, Signal::USR2);
+    kill_this(Signal::USR2);
+    assert_eq!(r_usr2.recv(), Some(Signal::USR2));
+
+    // The following will terminate the process, as it is NOT blocked
+    // by the main thread.
+    kill_this(Signal::TERM);
+    unreachable!();
+}

--- a/examples/test_block_specific.rs
+++ b/examples/test_block_specific.rs
@@ -6,9 +6,11 @@ use chan_signal::{Signal, kill_this};
 
 fn main() {
     chan_signal::unblock_signals_by_default();
-    let r_usr1 = chan_signal::notify(&[Signal::USR1]);
+    let r_usr1 = chan_signal::notify(&[Signal::USR1, Signal::ALRM]);
     kill_this(Signal::USR1);
+    kill_this(Signal::ALRM);
     assert_eq!(r_usr1.recv(), Some(Signal::USR1));
+    assert_eq!(r_usr1.recv(), Some(Signal::ALRM));
 
     let (s, r_usr2) = chan::sync(1);
     chan_signal::notify_on(&s, Signal::USR2);

--- a/examples/test_block_specific.rs
+++ b/examples/test_block_specific.rs
@@ -5,7 +5,6 @@ extern crate chan_signal;
 use chan_signal::{Signal, kill_this};
 
 fn main() {
-    chan_signal::unblock_signals_by_default();
     let r_usr1 = chan_signal::notify(&[Signal::USR1, Signal::ALRM]);
     kill_this(Signal::USR1);
     kill_this(Signal::ALRM);

--- a/examples/test_one_not_other.rs
+++ b/examples/test_one_not_other.rs
@@ -3,9 +3,10 @@
 extern crate chan;
 extern crate chan_signal;
 
-use chan_signal::{Signal, kill_this};
+use chan_signal::{Signal, kill_this, block};
 
 fn main() {
+    block(&[Signal::TERM]);
     let (s, r) = chan::sync(1);
     chan_signal::notify_on(&s, Signal::HUP);
     kill_this(Signal::TERM);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,12 +203,13 @@ pub fn notify_on(chan: &Sender<Signal>, signal: Signal) {
         let mut sigs = BitSet::new();
         sigs.insert(signal.as_sig() as usize);
         subs.insert((*chan).clone(), sigs);
-
-        // Make sure that the signal that we want notifications on is blocked
-        let mut sig_set = SigSet::empty();
-        sig_set.add(signal.as_sig()).unwrap();
-        sig_set.thread_block_signals().unwrap();
     }
+
+    // Make sure that the signal that we want notifications on is blocked
+    // It does not matter if we unblock the same signal twice.
+    let mut sig_set = SigSet::empty();
+    sig_set.add(signal.as_sig()).unwrap();
+    sig_set.thread_block_signals().unwrap();
 }
 
 /// Unblock all subscribable signals that are blocked by default.


### PR DESCRIPTION
This should fix #2.

Calling the newly introduced function `unblock_signals_by_default` resets the mask of the process to an empty one. This has to be done before calling `notify` or `notify_on` (which is enforced at runtime). Subscribing to a signal via `notify_on` now (again) blocks the current signal, allowing it to be picked by `sigwait` in the watcher thread.

This works because if a signal arrives asynchronously from another process, it will be passed to one (arbitrary) thread that has not masked it. Only if there is no such thread (e.g., if one has subscribed to that signal via `notify_on`), it will be enqueued as pending and can then be picked up by `sigwait`. It should be noted that the worker thread still blocks and waits for all subscribable signals, but will just never receive a signal that is not also blocked by all other threads.

A nicer API would certainly be to not block any signals by default and maybe allow for opt-in blocking of certain signals via separate functions, but that would be a breaking change.