### PR TITLE
Fix link to docs in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ just like anything else.
 TL;DR - Spawn a thread, block on `sigwait`, deliver signals, repeat.
 
 It's
-[explained a bit more in the docs](http://burntsushi.net/rustdoc/chan_signal/#how-it-works).
+[explained a bit more in the docs](https://docs.rs/chan-signal/#how-it-works).


### PR DESCRIPTION
The previous link resulted in:
http://burntsushi.net/rustdoc/chan_signal/ → 302
https://docs.rs/chan_signal/ → 404

Fixes #18.