### PR TITLE
Add support for crossbeam-channel, with an optional feature flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ bit-set = "0.4"
 chan = "0.1"
 lazy_static = "0.2"
 libc = "0.2"
+
+[dependencies.crossbeam-channel]
+git = "https://github.com/crossbeam-rs/crossbeam-channel"
+optional = true


### PR DESCRIPTION
Naive port. Cannot be merged at the moment; it requires the Git master of crossbeam-channel because Hash/Eq/Ord for channels was just merged.

If this is ok for you, how should the examples/tests be handled?