### PR TITLE
Add Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,7 @@ license = "Unlicense/MIT"
 [dependencies]
 bit-set = "0.4"
 chan = "0.1"
+kernel32-sys = "0.2.1"
 lazy_static = "0.2"
 libc = "0.2"
+winapi = "0.3.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,10 +108,9 @@ additions may be warranted:
 * Support Windows.
 */
 #![deny(missing_docs)]
-#![allow(unused_imports)] // TODO: Remove
 
 extern crate bit_set;
-#[macro_use] extern crate chan;
+extern crate chan;
 #[macro_use] extern crate lazy_static;
 extern crate libc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,45 +108,25 @@ additions may be warranted:
 * Support Windows.
 */
 #![deny(missing_docs)]
+#![allow(unused_imports)] // TODO: Remove
 
 extern crate bit_set;
 #[macro_use] extern crate chan;
 #[macro_use] extern crate lazy_static;
 extern crate libc;
 
-use std::collections::HashMap;
-use std::io;
-use std::mem;
-use std::ptr;
-use std::sync::Mutex;
-use std::thread;
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+use unix::*;
 
-use bit_set::BitSet;
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+use windows::*;
+
 use chan::Sender;
-use libc::{
-    // POSIX.1-2008, minus SIGPOLL (not in some BSD, use SIGIO)
-    SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGABRT, SIGFPE, SIGKILL,
-    SIGSEGV, SIGPIPE, SIGALRM, SIGTERM, SIGUSR1, SIGUSR2,
-    SIGCHLD, SIGCONT, SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU,
-    SIGBUS, SIGPROF, SIGSYS, SIGTRAP, SIGURG, SIGVTALRM,
-    SIGXCPU, SIGXFSZ,
 
-    // Common Extensions (SIGINFO and SIGEMT not in libc)
-    SIGIO,
-    SIGWINCH,
-
-    SIG_BLOCK,
-    SIG_SETMASK,
-};
-use libc::kill;
-use libc::getpid;
-
-lazy_static! {
-    static ref HANDLERS: Mutex<HashMap<Sender<Signal>, BitSet>> = {
-        init();
-        Mutex::new(HashMap::new())
-    };
-}
 
 /// Create a new channel subscribed to the given signals.
 ///
@@ -197,18 +177,7 @@ pub fn notify(signals: &[Signal]) -> chan::Receiver<Signal> {
 /// **THIS MUST BE CALLED BEFORE ANY OTHER THREADS ARE SPAWNED IN YOUR
 /// PROCESS.**
 pub fn notify_on(chan: &Sender<Signal>, signal: Signal) {
-    let mut subs = HANDLERS.lock().unwrap();
-    if subs.contains_key(chan) {
-        subs.get_mut(chan).unwrap().insert(signal.as_sig() as usize);
-    } else {
-        let mut sigs = BitSet::new();
-        sigs.insert(signal.as_sig() as usize);
-        subs.insert((*chan).clone(), sigs);
-    }
-
-    // Make sure that the signal that we want notifications on is blocked
-    // It does not matter if we block the same signal twice.
-    block(&[signal]);
+    _notify_on(chan, signal);
 }
 
 /// Block all given signals without receiving notifications.
@@ -219,11 +188,7 @@ pub fn notify_on(chan: &Sender<Signal>, signal: Signal) {
 /// **THIS MUST BE CALLED BEFORE ANY OTHER THREADS ARE SPAWNED IN YOUR
 /// PROCESS.**
 pub fn block(signals: &[Signal]) {
-    let mut block = SigSet::empty();
-    for signal in signals {
-        block.add(signal.as_sig()).unwrap();
-    }
-    block.thread_block_signals().unwrap();
+    _block(signals);
 }
 
 /// Block all subscribable signals.
@@ -234,60 +199,11 @@ pub fn block(signals: &[Signal]) {
 /// **THIS MUST BE CALLED BEFORE ANY OTHER THREADS ARE SPAWNED IN YOUR
 /// PROCESS.**
 pub fn block_all_subscribable() {
-    SigSet::subscribable().thread_block_signals().unwrap();
+    _block_all_subscribable();
 }
 
-fn init() {
-    // First:
-    // Get the curren thread_mask. (We cannot just overwrite the threadmask with
-    // an empty one because this function is executed lazily.
-    let saved_mask = SigSet::current().unwrap();
-
-    // Then:
-    // Block all signals in this thread. The signal mask will then be inherited
-    // by the worker thread.
-    SigSet::subscribable().thread_set_signal_mask().unwrap();
-    thread::spawn(move || {
-        let mut listen = SigSet::subscribable();
-
-        loop {
-            let sig = listen.wait().unwrap();
-            let subs = HANDLERS.lock().unwrap();
-            for (s, sigs) in subs.iter() {
-                if !sigs.contains(sig as usize) {
-                    continue;
-                }
-                chan_select! {
-                    default => {},
-                    s.send(Signal::new(sig)) => {},
-                }
-            }
-        }
-    });
-
-    // Now:
-    // Reset to the previously saved sigmask.
-    // This whole procedure is necessary, as we cannot rely on the worker thread
-    // starting fast enough to set its signal mask. Otherwise an early SIGTERM or
-    // similar may take down the process even though the main thread has blocked
-    // the signal.
-    saved_mask.thread_set_signal_mask().unwrap();
-}
-
-/// Kill the current process. (Only used in tests.)
-#[doc(hidden)]
-pub fn kill_this(sig: Signal) {
-    unsafe { kill(getpid(), sig.as_sig()); }
-}
-
-type Sig = libc::c_int;
-
-/// The set of subscribable signals.
-///
-/// After the first call to `notify_on` (or `notify`), precisely this set of
-/// signals are set to blocked status.
 #[allow(missing_docs)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Signal {
     HUP,
     INT,
@@ -321,198 +237,3 @@ pub enum Signal {
     #[doc(hidden)]
     __NonExhaustiveMatch,
 }
-
-impl Signal {
-    fn new(sig: Sig) -> Signal {
-        match sig {
-            SIGHUP => Signal::HUP,
-            SIGINT => Signal::INT,
-            SIGQUIT => Signal::QUIT,
-            SIGILL => Signal::ILL,
-            SIGABRT => Signal::ABRT,
-            SIGFPE => Signal::FPE,
-            SIGKILL => Signal::KILL,
-            SIGSEGV => Signal::SEGV,
-            SIGPIPE => Signal::PIPE,
-            SIGALRM => Signal::ALRM,
-            SIGTERM => Signal::TERM,
-            SIGUSR1 => Signal::USR1,
-            SIGUSR2 => Signal::USR2,
-            SIGCHLD => Signal::CHLD,
-            SIGCONT => Signal::CONT,
-            SIGSTOP => Signal::STOP,
-            SIGTSTP => Signal::TSTP,
-            SIGTTIN => Signal::TTIN,
-            SIGTTOU => Signal::TTOU,
-            SIGBUS => Signal::BUS,
-            SIGPROF => Signal::PROF,
-            SIGSYS => Signal::SYS,
-            SIGTRAP => Signal::TRAP,
-            SIGURG => Signal::URG,
-            SIGVTALRM => Signal::VTALRM,
-            SIGXCPU => Signal::XCPU,
-            SIGXFSZ => Signal::XFSZ,
-            SIGIO => Signal::IO,
-            SIGWINCH => Signal::WINCH,
-            sig => panic!("unsupported signal number: {}", sig),
-        }
-    }
-
-    fn as_sig(self) -> Sig {
-        match self {
-            Signal::HUP => SIGHUP,
-            Signal::INT => SIGINT,
-            Signal::QUIT => SIGQUIT,
-            Signal::ILL => SIGILL,
-            Signal::ABRT => SIGABRT,
-            Signal::FPE => SIGFPE,
-            Signal::KILL => SIGKILL,
-            Signal::SEGV => SIGSEGV,
-            Signal::PIPE => SIGPIPE,
-            Signal::ALRM => SIGALRM,
-            Signal::TERM => SIGTERM,
-            Signal::USR1 => SIGUSR1,
-            Signal::USR2 => SIGUSR2,
-            Signal::CHLD => SIGCHLD,
-            Signal::CONT => SIGCONT,
-            Signal::STOP => SIGSTOP,
-            Signal::TSTP => SIGTSTP,
-            Signal::TTIN => SIGTTIN,
-            Signal::TTOU => SIGTTOU,
-            Signal::BUS => SIGBUS,
-            Signal::PROF => SIGPROF,
-            Signal::SYS => SIGSYS,
-            Signal::TRAP => SIGTRAP,
-            Signal::URG => SIGURG,
-            Signal::VTALRM => SIGVTALRM,
-            Signal::XCPU => SIGXCPU,
-            Signal::XFSZ => SIGXFSZ,
-            Signal::IO => SIGIO,
-            Signal::WINCH => SIGWINCH,
-            Signal::__NonExhaustiveMatch => unreachable!(),
-        }
-    }
-}
-
-/// Safe wrapper around `sigset_t`.
-struct SigSet(sigset_t);
-
-impl SigSet {
-    fn empty() -> SigSet {
-        let mut set = unsafe { mem::uninitialized() };
-        unsafe { sigemptyset(&mut set) };
-        SigSet(set)
-    }
-
-    fn current() -> io::Result<SigSet> {
-        let mut set = unsafe { mem::uninitialized() };
-        let ecode = unsafe {
-            pthread_sigmask(SIG_SETMASK, ptr::null_mut(), &mut set)
-        };
-        ok_errno(SigSet(set), ecode)
-    }
-
-    /// Creates a new signal set with precisely the signals we're limited
-    /// to subscribing to.
-    fn subscribable() -> SigSet {
-        let mut set = SigSet::empty();
-        set.add(SIGHUP).unwrap();
-        set.add(SIGINT).unwrap();
-        set.add(SIGQUIT).unwrap();
-        set.add(SIGILL).unwrap();
-        set.add(SIGABRT).unwrap();
-        set.add(SIGFPE).unwrap();
-        set.add(SIGKILL).unwrap();
-        set.add(SIGSEGV).unwrap();
-        set.add(SIGPIPE).unwrap();
-        set.add(SIGALRM).unwrap();
-        set.add(SIGTERM).unwrap();
-        set.add(SIGUSR1).unwrap();
-        set.add(SIGUSR2).unwrap();
-        set.add(SIGCHLD).unwrap();
-        set.add(SIGCONT).unwrap();
-        set.add(SIGSTOP).unwrap();
-        set.add(SIGTSTP).unwrap();
-        set.add(SIGTTIN).unwrap();
-        set.add(SIGTTOU).unwrap();
-        set.add(SIGBUS).unwrap();
-        set.add(SIGPROF).unwrap();
-        set.add(SIGSYS).unwrap();
-        set.add(SIGTRAP).unwrap();
-        set.add(SIGURG).unwrap();
-        set.add(SIGVTALRM,).unwrap();
-        set.add(SIGXCPU).unwrap();
-        set.add(SIGXFSZ).unwrap();
-        set.add(SIGIO).unwrap();
-        set.add(SIGWINCH).unwrap();
-        set
-    }
-
-    fn add(&mut self, sig: Sig) -> io::Result<()> {
-        unsafe { ok_errno((), sigaddset(&mut self.0, sig)) }
-    }
-
-    fn wait(&mut self) -> io::Result<Sig> {
-        let mut sig: Sig = 0;
-        let errno = unsafe { sigwait(&mut self.0, &mut sig) };
-        ok_errno(sig, errno)
-    }
-
-    fn thread_block_signals(&self) -> io::Result<()> {
-        let ecode = unsafe {
-            pthread_sigmask(SIG_BLOCK, &self.0, ptr::null_mut())
-        };
-        ok_errno((), ecode)
-    }
-
-    fn thread_set_signal_mask(&self) -> io::Result<()> {
-        let ecode = unsafe {
-            pthread_sigmask(SIG_SETMASK, &self.0, ptr::null_mut())
-        };
-        ok_errno((), ecode)
-    }
-}
-
-fn ok_errno<T>(ok: T, ecode: libc::c_int) -> io::Result<T> {
-    if ecode != 0 { Err(io::Error::from_raw_os_error(ecode)) } else { Ok(ok) }
-}
-
-extern {
-    fn sigwait(set: *mut sigset_t, sig: *mut Sig) -> Sig;
-    fn sigaddset(set: *mut sigset_t, sig: Sig) -> libc::c_int;
-    fn sigemptyset(set: *mut sigset_t) -> libc::c_int;
-    fn pthread_sigmask(
-        how: libc::c_int,
-        set: *const sigset_t,
-        oldset: *mut sigset_t,
-    ) -> libc::c_int;
-}
-
-// Most of this was lifted out of rust-lang:rust/src/libstd/sys/unix/c.rs.
-
-#[cfg(all(target_os = "linux", target_pointer_width = "32"))]
-#[repr(C)]
-struct sigset_t {
-    __val: [libc::c_ulong; 32],
-}
-
-#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
-#[repr(C)]
-struct sigset_t {
-    __val: [libc::c_ulong; 16],
-}
-
-#[cfg(target_os = "android")]
-type sigset_t = libc::c_ulong;
-
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-type sigset_t = u32;
-
-#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-#[repr(C)]
-struct sigset_t {
-    bits: [u32; 4],
-}
-
-#[cfg(any(target_os = "bitrig", target_os = "netbsd", target_os = "openbsd"))]
-type sigset_t = libc::c_uint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,8 @@ extern crate libc;
 mod unix;
 #[cfg(unix)]
 use unix::*;
+#[cfg(unix)]
+pub use unix::kill_this;
 
 #[cfg(windows)]
 mod windows;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ additions may be warranted:
 #![deny(missing_docs)]
 
 extern crate bit_set;
-extern crate chan;
+#[allow(unused_imports)] #[macro_use] extern crate chan;
 #[macro_use] extern crate lazy_static;
 extern crate libc;
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,5 +1,3 @@
-#[macro_use] extern crate chan;
-
 use libc;
 use libc::{
     // POSIX.1-2008, minus SIGPOLL (not in some BSD, use SIGIO)
@@ -102,6 +100,12 @@ fn init() {
     // similar may take down the process even though the main thread has blocked
     // the signal.
     saved_mask.thread_set_signal_mask().unwrap();
+}
+
+/// Kill the current process. (Only used in tests.)
+#[doc(hidden)]
+pub fn kill_this(sig: Signal) {
+    unsafe { kill(getpid(), sig.as_sig()); }
 }
 
 type Sig = libc::c_int;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,0 +1,297 @@
+use libc;
+use libc::{
+    // POSIX.1-2008, minus SIGPOLL (not in some BSD, use SIGIO)
+    SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGABRT, SIGFPE, SIGKILL,
+    SIGSEGV, SIGPIPE, SIGALRM, SIGTERM, SIGUSR1, SIGUSR2,
+    SIGCHLD, SIGCONT, SIGSTOP, SIGTSTP, SIGTTIN, SIGTTOU,
+    SIGBUS, SIGPROF, SIGSYS, SIGTRAP, SIGURG, SIGVTALRM,
+    SIGXCPU, SIGXFSZ,
+
+    // Common Extensions (SIGINFO and SIGEMT not in libc)
+    SIGIO,
+    SIGWINCH,
+
+    SIG_BLOCK,
+    SIG_SETMASK,
+};
+use libc::kill;
+use libc::getpid;
+
+use std::collections::HashMap;
+use std::io;
+use std::mem;
+use std::ptr;
+use std::sync::Mutex;
+use std::thread;
+
+use bit_set::BitSet;
+use chan::Sender;
+use super::Signal;
+
+lazy_static! {
+    static ref HANDLERS: Mutex<HashMap<Sender<Signal>, BitSet>> = {
+        init();
+        Mutex::new(HashMap::new())
+    };
+}
+
+#[doc(hidden)]
+pub fn _notify_on(chan: &Sender<Signal>, signal: Signal) {
+    let mut subs = HANDLERS.lock().unwrap();
+    if subs.contains_key(chan) {
+        subs.get_mut(chan).unwrap().insert(signal.as_sig() as usize);
+    } else {
+        let mut sigs = BitSet::new();
+        sigs.insert(signal.as_sig() as usize);
+        subs.insert((*chan).clone(), sigs);
+    }
+
+    // Make sure that the signal that we want notifications on is blocked
+    // It does not matter if we block the same signal twice.
+    _block(&[signal]);
+}
+
+#[doc(hidden)]
+pub fn _block(signals: &[Signal]) {
+    let mut block = SigSet::empty();
+    for signal in signals {
+        block.add(signal.as_sig()).unwrap();
+    }
+    block.thread_block_signals().unwrap();
+}
+
+#[doc(hidden)]
+pub fn _block_all_subscribable() {
+    SigSet::subscribable().thread_block_signals().unwrap();
+}
+
+fn init() {
+    // First:
+    // Get the curren thread_mask. (We cannot just overwrite the threadmask with
+    // an empty one because this function is executed lazily.
+    let saved_mask = SigSet::current().unwrap();
+
+    // Then:
+    // Block all signals in this thread. The signal mask will then be inherited
+    // by the worker thread.
+    SigSet::subscribable().thread_set_signal_mask().unwrap();
+    thread::spawn(move || {
+        let mut listen = SigSet::subscribable();
+
+        loop {
+            let sig = listen.wait().unwrap();
+            let subs = HANDLERS.lock().unwrap();
+            for (s, sigs) in subs.iter() {
+                if !sigs.contains(sig as usize) {
+                    continue;
+                }
+                chan_select! {
+                    default => {},
+                    s.send(Signal::new(sig)) => {},
+                }
+            }
+        }
+    });
+
+    // Now:
+    // Reset to the previously saved sigmask.
+    // This whole procedure is necessary, as we cannot rely on the worker thread
+    // starting fast enough to set its signal mask. Otherwise an early SIGTERM or
+    // similar may take down the process even though the main thread has blocked
+    // the signal.
+    saved_mask.thread_set_signal_mask().unwrap();
+}
+
+type Sig = libc::c_int;
+
+impl Signal {
+    fn new(sig: Sig) -> Signal {
+        match sig {
+            SIGHUP => Signal::HUP,
+            SIGINT => Signal::INT,
+            SIGQUIT => Signal::QUIT,
+            SIGILL => Signal::ILL,
+            SIGABRT => Signal::ABRT,
+            SIGFPE => Signal::FPE,
+            SIGKILL => Signal::KILL,
+            SIGSEGV => Signal::SEGV,
+            SIGPIPE => Signal::PIPE,
+            SIGALRM => Signal::ALRM,
+            SIGTERM => Signal::TERM,
+            SIGUSR1 => Signal::USR1,
+            SIGUSR2 => Signal::USR2,
+            SIGCHLD => Signal::CHLD,
+            SIGCONT => Signal::CONT,
+            SIGSTOP => Signal::STOP,
+            SIGTSTP => Signal::TSTP,
+            SIGTTIN => Signal::TTIN,
+            SIGTTOU => Signal::TTOU,
+            SIGBUS => Signal::BUS,
+            SIGPROF => Signal::PROF,
+            SIGSYS => Signal::SYS,
+            SIGTRAP => Signal::TRAP,
+            SIGURG => Signal::URG,
+            SIGVTALRM => Signal::VTALRM,
+            SIGXCPU => Signal::XCPU,
+            SIGXFSZ => Signal::XFSZ,
+            SIGIO => Signal::IO,
+            SIGWINCH => Signal::WINCH,
+            sig => panic!("unsupported signal number: {}", sig),
+        }
+    }
+
+    fn as_sig(self) -> Sig {
+        match self {
+            Signal::HUP => SIGHUP,
+            Signal::INT => SIGINT,
+            Signal::QUIT => SIGQUIT,
+            Signal::ILL => SIGILL,
+            Signal::ABRT => SIGABRT,
+            Signal::FPE => SIGFPE,
+            Signal::KILL => SIGKILL,
+            Signal::SEGV => SIGSEGV,
+            Signal::PIPE => SIGPIPE,
+            Signal::ALRM => SIGALRM,
+            Signal::TERM => SIGTERM,
+            Signal::USR1 => SIGUSR1,
+            Signal::USR2 => SIGUSR2,
+            Signal::CHLD => SIGCHLD,
+            Signal::CONT => SIGCONT,
+            Signal::STOP => SIGSTOP,
+            Signal::TSTP => SIGTSTP,
+            Signal::TTIN => SIGTTIN,
+            Signal::TTOU => SIGTTOU,
+            Signal::BUS => SIGBUS,
+            Signal::PROF => SIGPROF,
+            Signal::SYS => SIGSYS,
+            Signal::TRAP => SIGTRAP,
+            Signal::URG => SIGURG,
+            Signal::VTALRM => SIGVTALRM,
+            Signal::XCPU => SIGXCPU,
+            Signal::XFSZ => SIGXFSZ,
+            Signal::IO => SIGIO,
+            Signal::WINCH => SIGWINCH,
+            Signal::__NonExhaustiveMatch => unreachable!(),
+        }
+    }
+}
+
+struct SigSet(sigset_t);
+
+impl SigSet {
+    fn empty() -> SigSet {
+        let mut set = unsafe { mem::uninitialized() };
+        unsafe { sigemptyset(&mut set) };
+        SigSet(set)
+    }
+
+    fn current() -> io::Result<SigSet> {
+        let mut set = unsafe { mem::uninitialized() };
+        let ecode = unsafe {
+            pthread_sigmask(SIG_SETMASK, ptr::null_mut(), &mut set)
+        };
+        ok_errno(SigSet(set), ecode)
+    }
+
+    /// Creates a new signal set with precisely the signals we're limited
+    /// to subscribing to.
+    fn subscribable() -> SigSet {
+        let mut set = SigSet::empty();
+        set.add(SIGHUP).unwrap();
+        set.add(SIGINT).unwrap();
+        set.add(SIGQUIT).unwrap();
+        set.add(SIGILL).unwrap();
+        set.add(SIGABRT).unwrap();
+        set.add(SIGFPE).unwrap();
+        set.add(SIGKILL).unwrap();
+        set.add(SIGSEGV).unwrap();
+        set.add(SIGPIPE).unwrap();
+        set.add(SIGALRM).unwrap();
+        set.add(SIGTERM).unwrap();
+        set.add(SIGUSR1).unwrap();
+        set.add(SIGUSR2).unwrap();
+        set.add(SIGCHLD).unwrap();
+        set.add(SIGCONT).unwrap();
+        set.add(SIGSTOP).unwrap();
+        set.add(SIGTSTP).unwrap();
+        set.add(SIGTTIN).unwrap();
+        set.add(SIGTTOU).unwrap();
+        set.add(SIGBUS).unwrap();
+        set.add(SIGPROF).unwrap();
+        set.add(SIGSYS).unwrap();
+        set.add(SIGTRAP).unwrap();
+        set.add(SIGURG).unwrap();
+        set.add(SIGVTALRM,).unwrap();
+        set.add(SIGXCPU).unwrap();
+        set.add(SIGXFSZ).unwrap();
+        set.add(SIGIO).unwrap();
+        set.add(SIGWINCH).unwrap();
+        set
+    }
+
+    fn add(&mut self, sig: Sig) -> io::Result<()> {
+        unsafe { ok_errno((), sigaddset(&mut self.0, sig)) }
+    }
+
+    fn wait(&mut self) -> io::Result<Sig> {
+        let mut sig: Sig = 0;
+        let errno = unsafe { sigwait(&mut self.0, &mut sig) };
+        ok_errno(sig, errno)
+    }
+
+    fn thread_block_signals(&self) -> io::Result<()> {
+        let ecode = unsafe {
+            pthread_sigmask(SIG_BLOCK, &self.0, ptr::null_mut())
+        };
+        ok_errno((), ecode)
+    }
+
+    fn thread_set_signal_mask(&self) -> io::Result<()> {
+        let ecode = unsafe {
+            pthread_sigmask(SIG_SETMASK, &self.0, ptr::null_mut())
+        };
+        ok_errno((), ecode)
+    }
+}
+
+fn ok_errno<T>(ok: T, ecode: libc::c_int) -> io::Result<T> {
+    if ecode != 0 { Err(io::Error::from_raw_os_error(ecode)) } else { Ok(ok) }
+}
+
+extern {
+    fn sigwait(set: *mut sigset_t, sig: *mut Sig) -> Sig;
+    fn sigaddset(set: *mut sigset_t, sig: Sig) -> libc::c_int;
+    fn sigemptyset(set: *mut sigset_t) -> libc::c_int;
+    fn pthread_sigmask(
+        how: libc::c_int,
+        set: *const sigset_t,
+        oldset: *mut sigset_t,
+    ) -> libc::c_int;
+}
+
+#[cfg(all(target_os = "linux", target_pointer_width = "32"))]
+#[repr(C)]
+struct sigset_t {
+    __val: [libc::c_ulong; 32],
+}
+
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+#[repr(C)]
+struct sigset_t {
+    __val: [libc::c_ulong; 16],
+}
+
+#[cfg(target_os = "android")]
+type sigset_t = libc::c_ulong;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+type sigset_t = u32;
+
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+#[repr(C)]
+struct sigset_t {
+    bits: [u32; 4],
+}
+
+#[cfg(any(target_os = "bitrig", target_os = "netbsd", target_os = "openbsd"))]
+type sigset_t = libc::c_uint;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,3 +1,5 @@
+#[macro_use] extern crate chan;
+
 use libc;
 use libc::{
     // POSIX.1-2008, minus SIGPOLL (not in some BSD, use SIGIO)

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,3 +1,4 @@
+extern crate chan;
 extern crate kernel32;
 extern crate winapi;
 
@@ -5,7 +6,6 @@ use std::collections::{HashSet, HashMap};
 use std::io;
 use std::sync::Mutex;
 
-use bit_set::BitSet;
 use chan::Sender;
 
 use self::winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,93 @@
+extern crate kernel32;
+extern crate winapi;
+
+use std::collections::{HashSet, HashMap};
+use std::io;
+use std::sync::Mutex;
+
+use bit_set::BitSet;
+use chan::Sender;
+
+use self::winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
+use super::Signal;
+
+const CTRL_C_EVENT: DWORD = 0;
+const CTRL_BREAK_EVENT: DWORD = 1;
+const CTRL_CLOSE_EVENT: DWORD = 2;
+
+lazy_static! {
+    static ref HANDLERS: Mutex<HashMap<Sender<Signal>, HashSet<Signal>>> = {
+        init().unwrap();
+        Mutex::new(HashMap::new())
+    };
+
+    static ref BLOCK: Mutex<HashSet<Signal>> = Mutex::new(HashSet::new());
+}
+
+unsafe extern "system" fn ctrl_handler(ctrl_type: DWORD) -> BOOL {
+    let sig = Signal::new(ctrl_type);
+    if !BLOCK.lock().unwrap().contains(&sig) {
+        return FALSE;
+    }
+
+    let subs = HANDLERS.lock().unwrap();
+    for (s, sigs) in subs.iter() {
+        if sigs.contains(&sig) {
+            s.send(sig);
+        }
+    }
+
+    TRUE
+}
+
+#[doc(hidden)]
+pub fn _notify_on(chan: &Sender<Signal>, signal: Signal) {
+    let mut subs = HANDLERS.lock().unwrap();
+    if subs.contains_key(chan) {
+        subs.get_mut(chan).unwrap().insert(signal);
+    } else {
+        let mut sigs = HashSet::new();
+        sigs.insert(signal);
+        subs.insert((*chan).clone(), sigs);
+    }
+
+    // Make sure that the signal that we want notifications on is blocked
+    // It does not matter if we block the same signal twice.
+    _block(&[signal]);
+}
+
+#[doc(hidden)]
+pub fn _block(signals: &[Signal]) {
+    let mut blocks = BLOCK.lock().unwrap();
+    for signal in signals {
+        blocks.insert(*signal);
+    }
+}
+
+#[doc(hidden)]
+pub fn _block_all_subscribable() {
+    for signal in &[Signal::INT, Signal::TERM] {
+        _block(&[*signal]);
+    }
+}
+
+fn init() -> Result<(), io::Error> {
+    unsafe {
+        if kernel32::SetConsoleCtrlHandler(Some(ctrl_handler), TRUE) == FALSE {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    Ok(())
+}
+
+impl Signal {
+    fn new(sig: DWORD) -> Signal {
+        match sig {
+            CTRL_C_EVENT => Signal::INT,
+            CTRL_BREAK_EVENT => Signal::INT,
+            CTRL_CLOSE_EVENT => Signal::TERM,
+            _ => panic!("unsupported win signal {:?}", sig)
+        }
+    }
+}


### PR DESCRIPTION
This pull request entails implementing Windows support in a path-of-least-resistance way.  Three of the main functions, notify_on, block, and block_all_subscribable have been delegated to platform-specific crates.  The Windows CtrlC and CtrlBreak events map to Signal::INT, and the CtrlClose event maps to Signal::TERM.

I do have a more complete solution in mind that would allow fine-grained control over the Windows events instead of simply mapping them to the equivalent Unix events, but that can happen in a later conversation, pending whether or not this pull request is accepted.