### PR TITLE
Use crossbeam-channel instead of chan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ license = "Unlicense/MIT"
 
 [dependencies]
 bit-set = "0.4"
-chan = "0.1"
 lazy_static = "0.2"
 libc = "0.2"
+crossbeam-channel = "0.2"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,6 @@
 // OS signals. Namely, it requests to be notified about a SIGINT (usually
 // ^C in your terminal) and blocks until it gets one.
 
-#[macro_use] extern crate chan;
 extern crate chan_signal;
 
 use chan_signal::{Signal, notify};

--- a/examples/sleep.rs
+++ b/examples/sleep.rs
@@ -1,4 +1,3 @@
-#[macro_use] extern crate chan;
 extern crate chan_signal;
 
 use std::thread;

--- a/examples/test_block_specific.rs
+++ b/examples/test_block_specific.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate chan;
+extern crate crossbeam_channel;
 extern crate chan_signal;
 
 use chan_signal::{Signal, kill_this};
@@ -11,7 +10,7 @@ fn main() {
     assert_eq!(r_usr1.recv(), Some(Signal::USR1));
     assert_eq!(r_usr1.recv(), Some(Signal::ALRM));
 
-    let (s, r_usr2) = chan::sync(1);
+    let (s, r_usr2) = crossbeam_channel::bounded(1);
     chan_signal::notify_on(&s, Signal::USR2);
     kill_this(Signal::USR2);
     assert_eq!(r_usr2.recv(), Some(Signal::USR2));

--- a/examples/test_many.rs
+++ b/examples/test_many.rs
@@ -1,12 +1,11 @@
-#[macro_use]
-extern crate chan;
+extern crate crossbeam_channel;
 extern crate chan_signal;
 
 use chan_signal::{Signal, kill_this};
 
 fn main() {
-    let (s1, r1) = chan::sync(1);
-    let (s2, r2) = chan::sync(1);
+    let (s1, r1) = crossbeam_channel::bounded(1);
+    let (s2, r2) = crossbeam_channel::bounded(1);
     chan_signal::notify_on(&s1, Signal::HUP);
     chan_signal::notify_on(&s2, Signal::TERM);
     kill_this(Signal::HUP);

--- a/examples/test_many_to_one.rs
+++ b/examples/test_many_to_one.rs
@@ -1,12 +1,11 @@
-#[macro_use]
-extern crate chan;
+extern crate crossbeam_channel;
 extern crate chan_signal;
 
 use chan_signal::{Signal, kill_this};
 
 fn main() {
-    let (s1, r1) = chan::sync(1);
-    let (s2, r2) = chan::sync(1);
+    let (s1, r1) = crossbeam_channel::bounded(1);
+    let (s2, r2) = crossbeam_channel::bounded(1);
     chan_signal::notify_on(&s1, Signal::HUP);
     chan_signal::notify_on(&s2, Signal::HUP);
     kill_this(Signal::HUP);

--- a/examples/test_one.rs
+++ b/examples/test_one.rs
@@ -1,11 +1,10 @@
-#[macro_use]
-extern crate chan;
+extern crate crossbeam_channel;
 extern crate chan_signal;
 
 use chan_signal::{Signal, kill_this};
 
 fn main() {
-    let (s, r) = chan::sync(1);
+    let (s, r) = crossbeam_channel::bounded(1);
     chan_signal::notify_on(&s, Signal::HUP);
     kill_this(Signal::HUP);
     assert_eq!(r.recv(), Some(Signal::HUP));

--- a/examples/test_one_not_other.rs
+++ b/examples/test_one_not_other.rs
@@ -1,13 +1,11 @@
-
-#[macro_use]
-extern crate chan;
+extern crate crossbeam_channel;
 extern crate chan_signal;
 
 use chan_signal::{Signal, kill_this, block};
 
 fn main() {
     block(&[Signal::TERM]);
-    let (s, r) = chan::sync(1);
+    let (s, r) = crossbeam_channel::bounded(1);
     chan_signal::notify_on(&s, Signal::HUP);
     kill_this(Signal::TERM);
     kill_this(Signal::HUP);

--- a/examples/test_sleep.rs
+++ b/examples/test_sleep.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate chan;
+extern crate crossbeam_channel;
 extern crate chan_signal;
 
 use std::thread;
@@ -8,7 +7,7 @@ use std::time::Duration;
 use chan_signal::{Signal, kill_this};
 
 fn main() {
-    let (s, r) = chan::sync(1);
+    let (s, r) = crossbeam_channel::bounded(1);
     chan_signal::notify_on(&s, Signal::HUP);
     thread::spawn(move || thread::sleep(Duration::from_secs(10)));
     thread::sleep(Duration::from_millis(500));

--- a/examples/test_usr1.rs
+++ b/examples/test_usr1.rs
@@ -1,11 +1,10 @@
-#[macro_use]
-extern crate chan;
+extern crate crossbeam_channel;
 extern crate chan_signal;
 
 use chan_signal::{Signal, kill_this};
 
 fn main() {
-    let (s, r) = chan::sync(1);
+    let (s, r) = crossbeam_channel::bounded(1);
     chan_signal::notify_on(&s, Signal::USR1);
     kill_this(Signal::USR1);
     assert_eq!(r.recv(), Some(Signal::USR1));


### PR DESCRIPTION
This replace the usage of the `chan` crate with the similar `crossbeam-channel`.

The API is almost identical.
* `chan::sync` is now `crossbeam_channel::bounded`
* `chan::async` is now `crossbeam_channel::unbounded`
* `chan_select!` is now `select!` and has a few syntactic changes (see examples or Readme.md)